### PR TITLE
Fix NA comparisons to use `==` instead of `is`

### DIFF
--- a/nputop/api/device.py
+++ b/nputop/api/device.py
@@ -205,7 +205,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
         return self.memory_info().free
 
     def memory_total_human(self) -> str | NaType:
-        if self._memory_total_human is NA:
+        if self._memory_total_human == NA:
             self._memory_total_human = bytes2human(self.memory_total())
         return self._memory_total_human
 

--- a/nputop/api/libascend.py
+++ b/nputop/api/libascend.py
@@ -122,7 +122,7 @@ def ascendDeviceGetProcessInfo(i:int):
     return [ProcInfo(pid,mem) for pid,mem in _CACHE.get(id,{}).get("procs",[])]
 
 def nvmlCheckReturn(v:Any, t:type|tuple[type,...]|None=None)->bool:
-    return v is not NA and (isinstance(v,t) if t else True)
+    return v != NA and (isinstance(v,t) if t else True)
 
 def nvmlQuery(func:Callable|str,*a,default:Any=NA,**kw)->Any:
     try:

--- a/nputop/api/process.py
+++ b/nputop/api/process.py
@@ -796,7 +796,7 @@ class NpuProcess:  # pylint: disable=too-many-instance-attributes,too-many-publi
             manager :meth:`NpuProcess.failsafe`. See also :meth:`take_snapshots` and :meth:`failsafe`.
         """
         running_time = self.running_time()
-        if running_time is NA:
+        if running_time == NA:
             return NA
         return running_time.total_seconds()
 

--- a/nputop/api/utils.py
+++ b/nputop/api/utils.py
@@ -205,7 +205,7 @@ class NaType(str):
         """  # pylint: disable=line-too-long
         if isinstance(other, (int, float)):
             return float(self) + other
-        if other is NA:
+        if other == NA:
             return float(self)
         return super().__add__(other)  # type: ignore[operator]
 
@@ -237,7 +237,7 @@ class NaType(str):
         """
         if isinstance(other, (int, float)):
             return float(self) - other
-        if other is NA:
+        if other == NA:
             return float(self)
         return NotImplemented
 
@@ -269,7 +269,7 @@ class NaType(str):
         """
         if isinstance(other, (int, float)):
             return float(self) * other
-        if other is NA:
+        if other == NA:
             return float(self)
         return NotImplemented
 
@@ -301,7 +301,7 @@ class NaType(str):
         """
         if isinstance(other, (int, float)):
             return float(self) / other
-        if other is NA:
+        if other == NA:
             return float(self)
         return NotImplemented
 
@@ -333,7 +333,7 @@ class NaType(str):
         """
         if isinstance(other, (int, float)):
             return float(self) // other
-        if other is NA:
+        if other == NA:
             return float(self)
         return NotImplemented
 
@@ -363,7 +363,7 @@ class NaType(str):
         """
         if isinstance(other, (int, float)):
             return float(self) % other
-        if other is NA:
+        if other == NA:
             return float(self)
         return NotImplemented
 

--- a/nputop/gui/library/device.py
+++ b/nputop/gui/library/device.py
@@ -159,7 +159,7 @@ class Device(DeviceBase):
             'memory': Device.MEMORY_UTILIZATION_THRESHOLDS,
             'npu': Device.NPU_UTILIZATION_THRESHOLDS,
         }.get(type)
-        if utilization is NA:
+        if utilization == NA:
             return 'moderate'
         if isinstance(utilization, str):
             utilization = utilization.replace('%', '')

--- a/nputop/gui/library/history.py
+++ b/nputop/gui/library/history.py
@@ -207,7 +207,7 @@ class HistoryGraph:  # pylint: disable=too-many-instance-attributes
             return NA
 
     def add(self, value):
-        if value is NA:
+        if value == NA:
             value = self.baseline - 0.1
         if not isinstance(value, (int, float)):
             return
@@ -340,7 +340,7 @@ class BufferedHistoryGraph(HistoryGraph):
         return last_value
 
     def add(self, value):
-        if value is NA:
+        if value == NA:
             value = self.baseline - 0.1
         if not isinstance(value, (int, float)):
             return

--- a/nputop/gui/library/process.py
+++ b/nputop/gui/library/process.py
@@ -37,7 +37,7 @@ class NpuProcess(NpuProcessBase):
     def host_snapshot(self) -> Snapshot:
         host_snapshot = super().host_snapshot()
 
-        if host_snapshot.cpu_percent is NA:
+        if host_snapshot.cpu_percent == NA:
             host_snapshot.cpu_percent_string = NA
         elif host_snapshot.cpu_percent < 1000.0:
             host_snapshot.cpu_percent_string = f'{host_snapshot.cpu_percent:.1f}%'
@@ -46,7 +46,7 @@ class NpuProcess(NpuProcessBase):
         else:
             host_snapshot.cpu_percent_string = '9999+%'
 
-        if host_snapshot.memory_percent is NA:
+        if host_snapshot.memory_percent == NA:
             host_snapshot.memory_percent_string = NA
         else:
             host_snapshot.memory_percent_string = f'{host_snapshot.memory_percent:.1f}%'
@@ -57,7 +57,7 @@ class NpuProcess(NpuProcessBase):
         snapshot = super().as_snapshot(host_process_snapshot_cache=host_process_snapshot_cache)
 
         snapshot.type = snapshot.type.replace('C+G', 'X')
-        if snapshot.npu_memory_human is NA and (host.WINDOWS or host.WSL):
+        if snapshot.npu_memory_human == NA and (host.WINDOWS or host.WSL):
             snapshot.npu_memory_human = 'WDDM:N/A'
 
         snapshot.cpu_percent_string = snapshot.host.cpu_percent_string

--- a/nputop/gui/screens/main/device.py
+++ b/nputop/gui/screens/main/device.py
@@ -147,7 +147,7 @@ class DevicePanel(Displayable):  # pylint: disable=too-many-instance-attributes
                 device.name = device.name.replace('NVIDIA ', '', 1)
             if device.is_mig_device:
                 device.name = device.name.rpartition(' ')[-1]
-                if device.bar1_memory_percent is not NA:
+                if device.bar1_memory_percent != NA:
                     device.bar1_memory_percent = round(device.bar1_memory_percent)
                     if device.bar1_memory_percent >= 100:
                         device.bar1_memory_percent_string = 'MAX'
@@ -166,7 +166,7 @@ class DevicePanel(Displayable):  # pylint: disable=too-many-instance-attributes
                 )
                 device.mig_mode = device.mig_mode.replace('N/A', 'N/A ')
                 device.compute_mode = device.compute_mode.replace('Exclusive', 'E.')
-                if device.fan_speed is not NA and device.fan_speed >= 100:
+                if device.fan_speed != NA and device.fan_speed >= 100:
                     device.fan_speed_string = 'MAX'
 
         with self.snapshot_lock:

--- a/nputop/gui/screens/main/host.py
+++ b/nputop/gui/screens/main/host.py
@@ -117,7 +117,7 @@ class HostPanel(Displayable):  # pylint: disable=too-many-instance-attributes
         )(host.swap_memory, get_value=lambda sm: sm.percent)
 
         def percentage(x):
-            return f'{x:.1f}%' if x is not NA else NA
+            return f'{x:.1f}%' if x != NA else NA
 
         def enable_history(device):
             device.memory_percent = BufferedHistoryGraph(
@@ -190,10 +190,10 @@ class HostPanel(Displayable):  # pylint: disable=too-many-instance-attributes
             memory_used = device.snapshot.memory_used
             memory_total = device.snapshot.memory_total
             npu_utilization = device.snapshot.npu_utilization
-            if memory_used is not NA and memory_total is not NA:
+            if memory_used != NA and memory_total != NA:
                 total_memory_used += memory_used
                 total_memory_total += memory_total
-            if npu_utilization is not NA:
+            if npu_utilization != NA:
                 npu_utilizations.append(float(npu_utilization))
         if total_memory_total > 0:
             self.average_npu_memory_percent.add(100.0 * total_memory_used / total_memory_total)

--- a/nputop/gui/screens/metrics.py
+++ b/nputop/gui/screens/metrics.py
@@ -137,17 +137,17 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
         total_npu_memory_human = bytes2human(total_npu_memory)
 
         def format_cpu_percent(value):
-            if value is NA:
+            if value == NA:
                 return f'CPU: {value}'
             return f'CPU: {value:.1f}%'
 
         def format_max_cpu_percent(value):
-            if value is NA:
+            if value == NA:
                 return f'MAX CPU: {value}'
             return f'MAX CPU: {value:.1f}%'
 
         def format_host_memory(value):
-            if value is NA:
+            if value == NA:
                 return f'HOST-MEM: {value}'
             return 'HOST-MEM: {} ({:.1f}%)'.format(  # noqa: UP032
                 bytes2human(value),
@@ -155,7 +155,7 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
             )
 
         def format_max_host_memory(value):
-            if value is NA:
+            if value == NA:
                 return f'MAX HOST-MEM: {value}'
             return 'MAX HOST-MEM: {} ({:.1f}%) / {}'.format(  # noqa: UP032
                 bytes2human(value),
@@ -164,7 +164,7 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
             )
 
         def format_npu_memory(value):
-            if value is not NA and total_npu_memory is not NA:
+            if value != NA and total_npu_memory != NA:
                 return 'NPU-MEM: {} ({:.1f}%)'.format(  # noqa: UP032
                     bytes2human(value),
                     round(100.0 * value / total_npu_memory, 1),
@@ -172,7 +172,7 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
             return f'NPU-MEM: {value}'
 
         def format_max_npu_memory(value):
-            if value is not NA and total_npu_memory is not NA:
+            if value != NA and total_npu_memory != NA:
                 return 'MAX NPU-MEM: {} ({:.1f}%) / {}'.format(  # noqa: UP032
                     bytes2human(value),
                     round(100.0 * value / total_npu_memory, 1),
@@ -181,12 +181,12 @@ class ProcessMetricsScreen(Displayable):  # pylint: disable=too-many-instance-at
             return f'MAX NPU-MEM: {value}'
 
         def format_sm(value):
-            if value is NA:
+            if value == NA:
                 return f'NPU-SM: {value}'
             return f'NPU-SM: {value:.1f}%'
 
         def format_max_sm(value):
-            if value is NA:
+            if value == NA:
                 return f'MAX NPU-SM: {value}'
             return f'MAX NPU-SM: {value:.1f}%'
 

--- a/nputop/gui/screens/treeview.py
+++ b/nputop/gui/screens/treeview.py
@@ -80,7 +80,7 @@ class TreeNode:  # pylint: disable=too-many-instance-attributes
                 except host.PsutilError:
                     cpu_percent = cpu_percent_string = NA
                 else:
-                    if cpu_percent is NA:
+                    if cpu_percent == NA:
                         cpu_percent_string = NA
                     elif cpu_percent < 1000.0:
                         cpu_percent_string = f'{cpu_percent:.1f}%'
@@ -94,7 +94,7 @@ class TreeNode:  # pylint: disable=too-many-instance-attributes
                 except host.PsutilError:
                     memory_percent = memory_percent_string = NA
                 else:
-                    if memory_percent is not NA:
+                    if memory_percent != NA:
                         memory_percent_string = f'{memory_percent:.1f}%'
                     else:
                         memory_percent_string = NA


### PR DESCRIPTION
**Problem**
`NA` comparisons in the code used `is`/`is not`, which can fail if a new `NaType` instance is created, modules are reloaded, or objects are copied/serialized. This caused subtle bugs in code relying on `NA` comparisons.

**Solution**
Replace all `NA` comparisons with `==`/`!=` to perform value-based checks. This ensures consistent and reliable behavior across different contexts while preserving existing string and numeric operations.

**Impact**

- Makes NA checks robust without changing existing functionality.
- Prevents subtle bugs related to identity checks.