### PR TITLE
fix: 兼容瞬时内存采样失败

### DIFF
--- a/nputop/api/device.py
+++ b/nputop/api/device.py
@@ -196,9 +196,28 @@ class Device:  # pylint: disable=too-many-instance-attributes
     # ------------------------------------------------------------
     # 内存
     # ------------------------------------------------------------
+    @staticmethod
+    def _normalize_memory_info(info: Any) -> MemoryInfo:
+        if isinstance(info, (tuple, list)) and len(info) >= 3:
+            total, free, used = info[:3]
+        else:
+            total = getattr(info, "total", NA)
+            free = getattr(info, "free", NA)
+            used = getattr(info, "used", NA)
+
+        if not all(isinstance(value, int) for value in (total, free, used)):
+            return MemoryInfo(total=NA, free=NA, used=NA)
+
+        return MemoryInfo(total=total, free=free, used=used)
+
     @memoize_when_activated
     def memory_info(self) -> MemoryInfo:
-        return libnvml.nvmlQuery("ascendDeviceGetMemoryInfo", self.index)
+        info = libnvml.nvmlQuery(
+            "ascendDeviceGetMemoryInfo",
+            self.index,
+            default=MemoryInfo(total=NA, free=NA, used=NA),
+        )
+        return self._normalize_memory_info(info)
 
     def memory_total(self) -> int | NaType:
         return self.memory_info().total
@@ -222,7 +241,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
 
     def memory_percent(self) -> float | NaType:
         info = self.memory_info()
-        if isinstance(info.total, int) and info.total:
+        if isinstance(info.total, int) and isinstance(info.used, int) and info.total:
             return round(100.0 * info.used / info.total, 1)
         return NA
 

--- a/nputop/api/libascend.py
+++ b/nputop/api/libascend.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-import subprocess, re, time, sys
+import subprocess, re, time, sys, threading
 from collections import namedtuple
 from types import ModuleType
 from typing import Any
@@ -34,6 +34,7 @@ _CACHE      : dict[int, dict[str,Any]] = {}   # 物理 id ↦ 数据
 _IDX        : list[int] = []                  # 逻辑 index ↦ 物理 id
 _CACHE_TTL  = 0.8
 _cache_ts   = 0.0
+_CACHE_LOCK = threading.RLock()
 _DRIVER_VERSION = None
 _POWER_LIMIT = {
     "310": None,
@@ -62,94 +63,105 @@ def _update_cache(raw: str = None) -> None:
     if time.time() - _cache_ts < _CACHE_TTL:
         return
 
-    if not raw:
-        raw = subprocess.run(
-            ["npu-smi","info"], text=True, capture_output=True, timeout=3
-        ).stdout
-    raw = raw.splitlines()
+    with _CACHE_LOCK:
+        if time.time() - _cache_ts < _CACHE_TTL:
+            return
 
-    data: dict[int, dict[str,Any]] = {}
-    
-    raw_iter = iter(raw)
-    next(raw_iter)
-    ln_l0 = next(raw_iter).strip()
-    if _DRIVER_VERSION is None:
-        m0 = _RE_R.match(ln_l0)
-        if m0:
-            _,_DRIVER_VERSION,_ = m0.groups()
-    for ln in raw_iter:
-        ln = ln.strip()
+        if not raw:
+            raw = subprocess.run(
+                ["npu-smi","info"], text=True, capture_output=True, timeout=3
+            ).stdout
+        raw = raw.splitlines()
 
-        m1 = _RE_L1.match(ln)
+        data: dict[int, dict[str,Any]] = {}
+        chip_phy: dict[tuple[int, int], int] = {}
         
-        if m1:
-            npu_id, name, ok, pwr, tmp = m1.groups()
-            cur_id = int(npu_id)
-            
-            ln1_data = dict(
-                name=name, health=ok,
-                power=float(pwr) * 1000 if (pwr != '-' and pwr != "NA") else NA + " ",
-                temp=int(tmp),
-                procs=[],
-                npu_id=cur_id,
-                chip_id=0,
-            )
-            
-            try:
-                ln_l2 = next(raw_iter).strip()
-            except StopIteration:
-                d = data.setdefault(cur_id, {})
-                d.update(ln1_data)
-                _npu_chip_phy[(d['npu_id'], d['chip_id'])] = cur_id
-                break 
+        raw_iter = iter(raw)
+        next(raw_iter)
+        ln_l0 = next(raw_iter).strip()
+        if _DRIVER_VERSION is None:
+            m0 = _RE_R.match(ln_l0)
+            if m0:
+                _,_DRIVER_VERSION,_ = m0.groups()
+        for ln in raw_iter:
+            ln = ln.strip()
 
-            m2 = _RE_L2.match(ln_l2)
+            m1 = _RE_L1.match(ln)
             
-            if m2:
-                chip_id, phy_id, bus, aic = m2.groups()
-                chip_id_kwargs = {'chip_id': int(chip_id)} if chip_id else {}
+            if m1:
+                npu_id, name, ok, pwr, tmp = m1.groups()
+                cur_id = int(npu_id)
 
-                if phy_id:
-                    cur_id = int(phy_id)
-                d = data.setdefault(cur_id, {})
-                d.update(ln1_data)
-
-                pair = re.findall(r'(\d+)\s*/\s*(\d+)', ln_l2)[-1]
-                h_used, h_tot = map(int, pair)
-                d.update(
-                    bus_id=bus,
-                    aicore=int(aic),
-                    hbm_used=h_used * 1024 * 1024,
-                    hbm_total=h_tot * 1024 * 1024,
-                    **chip_id_kwargs,
+                ln1_data = dict(
+                    name=name, health=ok,
+                    power=float(pwr) * 1000 if (pwr != '-' and pwr != "NA") else NA + " ",
+                    temp=int(tmp),
+                    procs=[],
+                    npu_id=cur_id,
+                    chip_id=0,
                 )
-                _npu_chip_phy[(d['npu_id'], d['chip_id'])] = cur_id
-            else:
-                d = data.setdefault(cur_id, {})
-                d.update(ln1_data)
-                _npu_chip_phy[(d['npu_id'], d['chip_id'])] = cur_id
 
-            continue
+                try:
+                    ln_l2 = next(raw_iter).strip()
+                except StopIteration:
+                    d = data.setdefault(cur_id, {})
+                    d.update(ln1_data)
+                    chip_phy[(d['npu_id'], d['chip_id'])] = cur_id
+                    break
 
-        mp = _RE_P.match(ln)
-        if mp:
-            npu_id, chip_id, pid, mem = map(int, mp.groups())
-            assert (npu_id, chip_id) in _npu_chip_phy, f"Process found for unknown NPU {npu_id} Chip {chip_id}"
-            d = data.setdefault(_npu_chip_phy[(npu_id, chip_id)], {})
-            d.setdefault("procs", []).append((pid, mem * 1024 * 1024))
+                m2 = _RE_L2.match(ln_l2)
 
-    for d in data.values():
-        d.setdefault("power", NA); d.setdefault("temp", NA)
-        d.setdefault("aicore", NA)
-        d.setdefault("hbm_used", 0); d.setdefault("hbm_total", 0)
-        d.setdefault("procs", [])
-        mem_pct = (round(100*d["hbm_used"]/d["hbm_total"],1)
-                   if d["hbm_total"] else NA)
-        d["util"] = Util(d["aicore"], mem_pct, NA, NA)
+                if m2:
+                    chip_id, phy_id, bus, aic = m2.groups()
+                    chip_id_kwargs = {'chip_id': int(chip_id)} if chip_id else {}
 
-    _CACHE.clear(); _CACHE.update(data)
-    _IDX.clear();   _IDX.extend(sorted(_CACHE.keys()))
-    _cache_ts = time.time()
+                    if phy_id:
+                        cur_id = int(phy_id)
+                    d = data.setdefault(cur_id, {})
+                    d.update(ln1_data)
+
+                    d.update(
+                        bus_id=bus,
+                        aicore=int(aic),
+                        **chip_id_kwargs,
+                    )
+                    pairs = re.findall(r'(\d+)\s*/\s*(\d+)', ln_l2)
+                    if pairs:
+                        h_used, h_tot = map(int, pairs[-1])
+                        d.update(
+                            hbm_used=h_used * 1024 * 1024,
+                            hbm_total=h_tot * 1024 * 1024,
+                        )
+                    chip_phy[(d['npu_id'], d['chip_id'])] = cur_id
+                else:
+                    d = data.setdefault(cur_id, {})
+                    d.update(ln1_data)
+                    chip_phy[(d['npu_id'], d['chip_id'])] = cur_id
+
+                continue
+
+            mp = _RE_P.match(ln)
+            if mp:
+                npu_id, chip_id, pid, mem = map(int, mp.groups())
+                phy_id = chip_phy.get((npu_id, chip_id))
+                if phy_id is None:
+                    continue
+                d = data.setdefault(phy_id, {})
+                d.setdefault("procs", []).append((pid, mem * 1024 * 1024))
+
+        for d in data.values():
+            d.setdefault("power", NA); d.setdefault("temp", NA)
+            d.setdefault("aicore", NA)
+            d.setdefault("hbm_used", 0); d.setdefault("hbm_total", 0)
+            d.setdefault("procs", [])
+            mem_pct = (round(100*d["hbm_used"]/d["hbm_total"],1)
+                       if d["hbm_total"] else NA)
+            d["util"] = Util(d["aicore"], mem_pct, NA, NA)
+
+        _CACHE.clear(); _CACHE.update(data)
+        _IDX.clear();   _IDX.extend(sorted(_CACHE.keys()))
+        _npu_chip_phy.clear(); _npu_chip_phy.update(chip_phy)
+        _cache_ts = time.time()
 
 def _phys(idx: int) -> int|None:
     _update_cache()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,24 @@
+from nputop.api import device as device_module
+from nputop.api.device import Device, MemoryInfo
+from nputop.api.utils import NA
+
+
+def test_memory_info_normalizes_failed_query(monkeypatch):
+    monkeypatch.setattr(device_module.libnvml, "nvmlQuery", lambda *args, **kwargs: NA)
+
+    device = Device(0)
+
+    assert device.memory_info() == MemoryInfo(total=NA, free=NA, used=NA)
+    assert device.memory_total() == NA
+    assert device.memory_free() == NA
+    assert device.memory_used() == NA
+    assert device.memory_percent() == NA
+
+
+def test_snapshot_survives_failed_memory_query(monkeypatch):
+    monkeypatch.setattr(device_module.libnvml, "nvmlQuery", lambda *args, **kwargs: NA)
+
+    snapshot = Device(0).as_snapshot()
+
+    assert snapshot.memory_info == MemoryInfo(total=NA, free=NA, used=NA)
+    assert snapshot.memory_used == NA

--- a/tests/test_libascend.py
+++ b/tests/test_libascend.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from nputop.api import libascend
@@ -270,11 +268,16 @@ TEST_CASES = [
 ]
 
 
-@pytest.mark.parametrize("raw,expected_cache", TEST_CASES)
-def test_npusmi_parse(raw, expected_cache):
+def reset_libascend_cache():
     libascend._CACHE.clear()
     libascend._IDX.clear()
-    time.sleep(1)
+    libascend._npu_chip_phy.clear()
+    libascend._cache_ts = 0.0
+
+
+@pytest.mark.parametrize("raw,expected_cache", TEST_CASES)
+def test_npusmi_parse(raw, expected_cache):
+    reset_libascend_cache()
 
     libascend._update_cache(raw)
 
@@ -285,3 +288,17 @@ def test_npusmi_parse(raw, expected_cache):
         cached_val = libascend._CACHE[key]
         for field, value in expected_val.items():
             assert cached_val[field] == value
+
+
+def test_npusmi_parse_ignores_transient_unknown_process():
+    raw = TEST_CASES[0][0].replace(
+        "| 0       0                 | 124528",
+        "| 7       0                 | 124528",
+    )
+    reset_libascend_cache()
+
+    libascend._update_cache(raw)
+
+    assert libascend._IDX == [0, 1]
+    assert libascend._CACHE[0]["procs"] == []
+    assert libascend._CACHE[1]["procs"] == []


### PR DESCRIPTION
修复 Ascend NPU 显存剧烈变化时，底层内存查询偶发返回 `N/A` 字符串，导致 snapshot 中访问 `.used` 崩溃的问题。

变更：
- 将失败的 `memory_info` 采样规范化为 `MemoryInfo(NA, NA, NA)`
- `npu-smi` 解析时跳过瞬时不一致的 process 行
- 给缓存刷新加锁，降低并发采样时的不一致风险
- 增加回归测试

测试：
- `PYTHONPATH=$PWD uvx --with pytest --with psutil --with cachetools --with termcolor pytest tests/test_libascend.py tests/test_device.py -q`
